### PR TITLE
Few commands are now available in DM

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -1,8 +1,8 @@
 ## Commands
 
 Alarm
-* `.alarm time [description]` - sets an alarm for `time` (format: 2000 -> 20:00) with the `description` (default value is "Alarm")
-* `.clearalarm` - clears alarm
+* `.alarm time [description]` - sets an alarm for `time` (format: 2000 -> 20:00) with the `description` (default value is "Alarm") (can be used in DM)
+* `.clearalarm` - clears alarm (can be used in DM)
 * `.settimezone offset` - sets the timezone, `offset` has the same format as `.alarm`'s `time` (0200 -> +02:00) (Authorized Role needed)
 
 
@@ -24,7 +24,7 @@ Logging
 Me
 * `.playing [name]` - if `name` is specified, sets the bot's playing tag, otherwise just displays it (Authorized Role needed)
 * `.say [text]` - the bot replies with `text`
-* `.help` - lists all commands
+* `.help` - lists all commands (can be used in DM)
 
 Music
 * `.ytplay youtube-link` - plays the audio of the given `youtube-link` (Authorized Role needed)

--- a/src/command_modules/alarm.js
+++ b/src/command_modules/alarm.js
@@ -55,6 +55,8 @@ function alarmTimer(message, storage) {
 
 const AlarmHandler = {
     AlarmHandler() {
+        this.canBeDM = true;
+
         this.ContentRegExpHandler(/^.alarm/);
     },
     handle(message, storage) {
@@ -99,6 +101,8 @@ Object.setPrototypeOf(AlarmHandler, ContentRegExpHandler);
 
 const ClearAlarmHandler = {
     ClearAlarmHandler() {
+        this.canBeDM = true;
+
         this.ContentRegExpHandler(/^.clearalarm/);
     },
     handle(message, storage) {

--- a/src/command_modules/me.js
+++ b/src/command_modules/me.js
@@ -42,6 +42,8 @@ Object.setPrototypeOf(SayHandler, ContentRegExpHandler);
 
 const HelpHandler = {
     HelpHandler() {
+        this.canBeDM = true;
+
         this.ContentRegExpHandler(/^.help/);
     },
     handle(message) {

--- a/src/server.js
+++ b/src/server.js
@@ -24,7 +24,12 @@ Configuration.reloadConfiguration()
 
         commandRouter.registerPreHandleHook(
             function filterTextChannelMessagePreHandleHook(handlerObject, message) {
-                return message.channel.type === "text";
+                if (handlerObject.canBeDM) {
+                    return message.channel.type === "text" ||
+                        message.channel.type === "dm";
+                } else {
+                    return message.channel.type === "text";
+                }
             }
         );
 
@@ -87,9 +92,9 @@ Configuration.reloadConfiguration()
                 if (!commandRouter.runPreHandleHooks(handlerObject, message)) {
                     return;
                 }
-    
+
                 handlerObject.handle(message, storage);
-    
+
                 commandRouter.runPostHandleHooks(handlerObject, message);
             }
         });


### PR DESCRIPTION
To avoid spamming public text channels a few commands, like 
* .alarm
* .clearalarm
* .help

are now available to use in DMs.