### PR TITLE
ContentRegExpHandler now matches commands correctly

### DIFF
--- a/src/content-regexp-handler.js
+++ b/src/content-regexp-handler.js
@@ -1,6 +1,6 @@
 const ContentRegExpHandler = {
     ContentRegExpHandler(regExp) {
-        this.regExp = regExp;
+        this.regExp = new RegExp(regExp.source + "($|\\s+)");
     },
     canHandle(message) {
         return this.regExp.test(message.content);


### PR DESCRIPTION
Command keywords, from now, can't be appended with more string.
Example: `.pokeasd` was the same as `.poke`